### PR TITLE
Update to match the Kentico Kontent configuration and allow for preview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ npm i rxjs --save (because this is a peer dependency of the Kentico Kontent Deli
 - Add `kentico-kontent-nuxt-module` to `modules` section of `nuxt.config.js`
 
 ```js
-
   /*
   ** Nuxt.js modules
   */

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ npm i rxjs --save (because this is a peer dependency of the Kentico Kontent Deli
     projectId: 'xxxx-xxx-xxxx-xxxx-xxxxx',
     enableAdvancedLogging: false,
     previewApiKey: 'xxxxxxxxxxxxxxxxxxxxxxxxxxx',
-    enablePreviewMode: true,
+    globalQueryConfig: {
+			usePreviewMode: true, // Queries the Delivery Preview API.
+		},
     baseUrl: 'https://custom.uri/api/KenticoKontentProxy',
     securedApiKey: 'xxx',
     enableSecuredMode: true

--- a/lib/module.js
+++ b/lib/module.js
@@ -5,7 +5,9 @@ module.exports = function kenticokontent (moduleOptions) {
     projectId: process.env.KENTICOKONTENT_PROJECTID || '',
     previewApiKey: process.env.KENTICOKONTENT_PREVIEWAPIKEY || null,
     enableAdvancedLogging: process.env.KENTICOKONTENT_ENABLEADVANCEDLOGGING || false,
-    enablePreviewMode: process.env.KENTICOKONTENT_ENABLEPREVIEWMODE || false,
+    globalQueryConfig: {
+			usePreviewMode: process.env.KENTICOKONTENT_ENABLEPREVIEWMODE || false
+		},
     defaultLanguage: process.env.KENTICOKONTENT_DEFAULTLANGUAGE || null,
     retryAttempts: process.env.KENTICOKONTENT_RETRYATTEMPTS || null,
     baseUrl: process.env.KENTICOKONTENT_BASEURL || null,

--- a/lib/templates/plugin.template.js
+++ b/lib/templates/plugin.template.js
@@ -5,8 +5,20 @@ export default (ctx, inject) => {
   // Create new  delivery client Instance
   let settings = JSON.parse('KENTICOOPTIONS')
 
-  // Add tracking header
-  settings = Object.assign({}, settings)
+  // Adds globalQueryConfig if not already set
+  if(!settings.globalQueryConfig)
+  {
+    settings.globalQueryConfig = {}    
+  }
+   // Adds customHeaders if not already set
+  if(!settings.globalQueryConfig.customHeaders)
+  {
+    settings.globalQueryConfig.customHeaders = []    
+  }
+  // Adds X-KC-SOURCE to identify this module is in use
+  settings.globalQueryConfig.customHeaders.push(
+    { header: 'X-KC-SOURCE', value: 'kentico-kontent-nuxt-module' } 
+  );
 
   const deliveryClient = new DeliveryClient(settings)
 

--- a/lib/templates/plugin.template.js
+++ b/lib/templates/plugin.template.js
@@ -6,13 +6,7 @@ export default (ctx, inject) => {
   let settings = JSON.parse('KENTICOOPTIONS')
 
   // Add tracking header
-  settings = Object.assign({}, settings, {
-    globalQueryConfig: {
-      customHeaders: [
-        { header: 'X-KC-SOURCE', value: 'kentico-kontent-nuxt-module' }
-      ]
-    }
-  })
+  settings = Object.assign({}, settings)
 
   const deliveryClient = new DeliveryClient(settings)
 

--- a/lib/templates/plugin.template.js
+++ b/lib/templates/plugin.template.js
@@ -4,17 +4,13 @@ import CacheService from '../services/CacheService'
 export default (ctx, inject) => {
   // Create new  delivery client Instance
   let settings = JSON.parse('KENTICOOPTIONS')
-
-  // Adds globalQueryConfig if not already set
-  if(!settings.globalQueryConfig)
-  {
-    settings.globalQueryConfig = {}    
-  }
+  
    // Adds customHeaders if not already set
   if(!settings.globalQueryConfig.customHeaders)
   {
     settings.globalQueryConfig.customHeaders = []    
   }
+
   // Adds X-KC-SOURCE to identify this module is in use
   settings.globalQueryConfig.customHeaders.push(
     { header: 'X-KC-SOURCE', value: 'kentico-kontent-nuxt-module' } 


### PR DESCRIPTION
HI! 
This PR is to modify the options structure passed into the Kentico DeliveryClient. The current one doesn't allow us to use preview mode as you couldn't write to globalQueryConfig.usePreviewMode as it was being overridden by the custom header. 

This code fixes that and also removes the old enablePreviewMode flag which is not used by the SDK anymore. See https://docs.kontent.ai/tutorials/develop-apps/build-strong-foundation/set-up-preview.
Thanks!


